### PR TITLE
Fix contentType field & suggest better "to" value for message receiver

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ http.post('/events', verifyRequest, function(req, res) {
 	var text = content.text;
 
 	// Refer to https://developers.line.me/businessconnect/api-reference#sending_message
-	sendMsg(config.echoBotMid, {
+	sendMsg(from, {
 		contentType: 1,
 		toType: 1,
 		text: 'respond'

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ http.post('/events', verifyRequest, function(req, res) {
 	// mid
 	var from = content.from;
 	// Content type would be possibly text/image/video/audio/gps/sticker/contact.
-	var type = content.type;
+	var type = content.contentType;
 	// assume it's text type here.
 	var text = content.text;
 


### PR DESCRIPTION
1. According to the bot document, field name "type" is not correct. The right field name is "contentType".
2. "to" field in sendMessage maybe can just use the original sender's id to let example clear. "config.echoBotMid" is not described in the document.
